### PR TITLE
Lando-ify all the WP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ vendor/
 !.gitignore
 !.env-sample
 !.travis.yml
+!.lando.yml
 
 # NPM Modules #
 ###############

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,38 @@
+# Set up some basic pantheon recipe config
+name: pantheon-wp-best-practices
+recipe: pantheon
+config:
+  framework: wordpress
+  env: lando
+  site: pantheon-wp-best-practices
+  id: 094f4627-a25e-4d60-8d5b-a3d99a7232bf
+  xdebug: true
+
+# Additionally spin up a node service so we can do gulp things
+services:
+  appserver:
+    build:
+      - cd $LANDO_MOUNT && ./bin/install-composer-dependencies.sh
+  node:
+    type: node:6
+    globals:
+      gulp-cli: "latest"
+    build:
+      - cd $LANDO_MOUNT && ./.circleci/build-gulp-assets.sh
+
+# Provide some tooling routes
+tooling:
+  npm:
+    service: node
+  node:
+    service: node
+  gulp:
+    service: node
+  yarn:
+    service: node
+
+# Automate some build steps that should happen after every start
+# events:
+#   post-start:
+#     - appserver: cd $LANDO_MOUNT && ./bin/install-composer-dependencies.sh
+#     - node: cd $LANDO_MOUNT && ./.circleci/build-gulp-assets.sh

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,6 +1,6 @@
 api_version: 1
 web_docroot: true
-php_version: 7.0
+php_version: 7.1
 workflows:
   deploy_product:
     after:


### PR DESCRIPTION
Holla holla @ataylorme 

So there are a few things to note here:

1. This uses "build" steps to run the composer and gulp steps. You COULD also use "events" which i left in but commented out. The big difference between the two is the events are going to run every time you start (which might not be what you want) and the build steps are going to run the first time you start an app, whenever the build steps change or if you "rebuild" the app. 
2. The composer script is failing so there might be some changes that are needed to make it more lando-friendly
3. `composer install` was failing complaining about needing 7.1 so i bumped the version, not sure if that is desirable 

Def let me know if you need any other help getting this 100% dialed