### PR TITLE
Fix files folder on deploy of master

### DIFF
--- a/.circleci/deploy-to-pantheon.sh
+++ b/.circleci/deploy-to-pantheon.sh
@@ -4,10 +4,10 @@ set -ex
 
 TERMINUS_DOES_MULTIDEV_EXIST()
 {
-    # Return 1 if on master since dev always exists
+    # Return 0 if on master since dev always exists
     if [[ ${CIRCLE_BRANCH} == "master" ]]
     then
-        return 1;
+        return 0;
     fi
     
     # Stash list of Pantheon multidev environments


### PR DESCRIPTION
We want a master deploy to hit L36 but the logic forces in into L33. You can test this logic with this snippet

```
test() {
 return 1;
}

if ! test
then
        echo "testpasses";
else
        echo "testfails";
fi
```